### PR TITLE
Add KISS (launcher).

### DIFF
--- a/ALTERNATIVES.md
+++ b/ALTERNATIVES.md
@@ -53,7 +53,7 @@ Certainly it would be great to have a comparative on resource usage tho. Wanna h
 
 ## ANDROID APPS
 
-* __Launcher__: Silverfish
+* __Launcher__: Silverfish -> [KISS](http://kisslauncher.com/)
 * __Facebook__: Tinfoil for Facebook
 * __Twitter__: Tinfoil for Twitter
 * __YouTube__: NewPipe


### PR DESCRIPTION
        - KISS is more lightweight than Silverfish (lower than 250KB,
          according to the app website) and highly customizable, so I
          decided to add this launcher to the list.