### PR TITLE
fix dtach link

### DIFF
--- a/ALTERNATIVES.md
+++ b/ALTERNATIVES.md
@@ -71,7 +71,7 @@ Most apps are from F-Droid, we are just starting.
 ## Command Line
 * __Commands Cheatsheet__: [CLI Companion](https://launchpad.net/clicompanion) -> [xman](https://www.x.org/archive/X11R7.5/doc/man/man1/xman.1.html) -> [cheat](https://github.com/chrisallenlane/cheat) / [howdoi](https://github.com/gleitz/howdoi) / [clf](https://github.com/ncrocfer/clf) / [fu](https://github.com/samirahmed/fu) / [bro](http://bropages.org/) -> [curl cht.sh/PROGRAM](https://github.com/chubin/cheat.sh)
 * __Copy and Move Progress Bar__: [progress](https://github.com/Xfennec/progress) -> [Advanced Copy](https://github.com/atdt/advcpmv)
-* __Daemonize__: [dtach](https://github.com/bogner/dtach) -> [abduco](https://github.com/martanne/abduco) -> [GNU Screen](https://www.gnu.org/software/screen/)
+* __Daemonize__: [dtach](https://github.com/crigler/dtach) -> [abduco](https://github.com/martanne/abduco) -> [GNU Screen](https://www.gnu.org/software/screen/)
 * __Directory Bookmarks__: [Apparix](https://micans.org/apparix/) -> [fasd](https://github.com/clvv/fasd)
 * __Framebuffer Environment__: [jfbterm](https://github.com/ruo91/jfbterm)/[Fbterm](https://code.google.com/archive/p/fbterm/) -> [yaft (because sixel)](https://github.com/uobikiemukot/yaft) -> [hterm (because regis)](https://github.com/new299/hackterm) -> [Fbpad](https://github.com/aligrudi/fbpad) -> [FramebufferUI](https://github.com/8l/fbui)
 * __Hacker Culture__: [ddate](https://github.com/bo0ts/ddate), [fortune](https://github.com/ruanyf/fortunes), [The Hacker Test](https://packages.debian.org/source/unstable/purity), [The Jargon File](https://packages.debian.org/source/unstable/jargon)


### PR DESCRIPTION
first of all HNY mayfrost and thanks for this awesome guides.

I found dtach link doesn't work after a bit of search I found 
[dtach sourceforge](http://dtach.sourceforge.net/) and inside it I found the link for github repo -in commit- but last commit was on Mar 6, 2017. with no active fork

**Fix dtach link**