### PR TITLE
added kilo text editor(>1000LOC, ~44kb)

### DIFF
--- a/ALTERNATIVES.md
+++ b/ALTERNATIVES.md
@@ -399,7 +399,7 @@ Most apps are from F-Droid, we are just starting.
 * __Speed Reading__: Flinks -> WordFlashReader -> GnomeRSVP -> spread0r -> [speedread](https://github.com/pasky/speedread)
 * __Spell Check__: Ispell -> [Aspell](https://directory.fsf.org/wiki/Aspell)
 * __Spreadsheets__: Libreoffice Calc -> Gnumeric -> Oleo -> [SC-IM](https://github.com/andmarti1424/sc-im)
-* __Text Editor__: Vim -> Nano -> Neovim -> Kakoune -> vile -> mg -> [GNU Zile](https://directory.fsf.org/wiki/GNU_Zile) (minimalist Emacs clone) -> nvi -> [Elvis](https://github.com/mbert/elvis) (minimalist Vi clone) -> ed
+* __Text Editor__: Vim -> Nano -> Neovim -> Kakoune -> vile -> mg -> [GNU Zile](https://directory.fsf.org/wiki/GNU_Zile) (minimalist Emacs clone) -> nvi -> [Elvis](https://github.com/mbert/elvis) (minimalist Vi clone) -> ed -> [kilo](https://github.com/antirez/kilo)
 * __Text Editor (IDE)__: Atom -> NetBeans -> Code Blocks -> Emacs (nox) -> Vim -> [xwpe](https://github.com/amagnasco/xwpe) (full IDE in the terminal)
 * __Text Encoding__: fuse-convmvfs, Dos2Unix, ASCII
 * __Text Formatting and Pretty Printing__: par -> fmt (Textutils) -> MSORT


### PR DESCRIPTION
Kilo is a small text editor in less than 1K lines of code (counted with cloc). It does not depend on any library (not even curses) and uses fairly standard VT100 (and similar terminals) escape sequences.
A screencast is available here: https://asciinema.org/a/90r2i9bq8po03nazhqtsifksb

Usage: kilo filename
CTRL-S: Save
CTRL-Q: Quit
CTRL-F: Find

https://github.com/antirez/kilo