### PR TITLE
Fix broken link

### DIFF
--- a/ALTERNATIVES.md
+++ b/ALTERNATIVES.md
@@ -106,7 +106,7 @@ Most apps are from F-Droid, we are just starting.
 * __Offline Reader__: [Kiwix](http://www.kiwix.org/) -> Darcy Ripper -> HTTrack -> [Stallman.js](https://github.com/isdampe/Stallman.js/tree/master) -> Wget
 * __Online Radio__: [Nuvola Player](https://tiliado.eu/nuvolaplayer/)
 * __RSS Feed and Podcast__: gPodder -> Raggle -> Liferea -> Newsbeuter (+ Podbeuter) -> Newsboat -> [sfeed](https://codemadness.org/git/sfeed/file/README.html)
-* __Search Engine Scraper__: Googler -> [Surfraw](http://surfraw.alioth.debian.org/) (+ [dmenu](https://bbs.archlinux.org/viewtopic.php?id=228706) or slmenu)
+* __Search Engine Scraper__: Googler -> [Surfraw](https://gitlab.com/surfraw/Surfraw) (+ [dmenu](https://bbs.archlinux.org/viewtopic.php?id=228706) or slmenu)
 * __Streams Catcher__: Streamripper -> youtube-dl -> [cclive](https://github.com/legatvs/cclive) -> [youtube-pl](http://ronja.twibright.com/youtube-pl.php) -> [RTMPDump](https://github.com/mstorsjo/rtmpdump) -> [quvi](https://github.com/mogaal/quvi)
 * __UPnP (DLNA) Client__: [djmount](https://github.com/Boxee/djmount)
 * __Usenet Client (Newsreader)__: Pan -> [slrn](http://www.slrn.org/) ( + slrnpull + slrnface) -> Trn


### PR DESCRIPTION
Fix Surfraw broken link
Broken link: http://surfraw.alioth.debian.org/
Replacement link: https://gitlab.com/surfraw/Surfraw/